### PR TITLE
Fix for sort type paramater when sent value is invalid

### DIFF
--- a/src/PerformsSorting.php
+++ b/src/PerformsSorting.php
@@ -30,6 +30,9 @@ trait PerformsSorting
 
         foreach ($columns as $column) {
             if ($column->getAttribute() == $sortField and ($column instanceof Sortable) and $column->isSortable()) {
+                if (!in_array(strtolower($sortType), ['asc', 'desc'])) {
+                    continue;
+                }
                 $queryBuilder = $column->sort($queryBuilder, $sortType);
             }
         }


### PR DESCRIPTION
Fix for #6 don't allow Laravel query builder to set an invalid sort type